### PR TITLE
assert: change the do-while of assert to a conditional expression

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -77,20 +77,10 @@
                                            __ASSERT_LINE__, msg, regs)
 
 #define __ASSERT__(f, file, line, _f) \
-  do                                  \
-    {                                 \
-      if (predict_false(!(f)))        \
-        __assert(file, line, _f);     \
-    }                                 \
-  while (0)
+  (predict_false(!(f))) ? __assert(file, line, _f) : ((void)0)
 
 #define __VERIFY__(f, file, line, _f) \
-  do                                  \
-    {                                 \
-      if (predict_false((f) < 0))     \
-        __assert(file, line, _f);     \
-    }                                 \
-  while (0)
+  (predict_false((f) < 0)) ? __assert(file, line, _f) : ((void)0)
 
 #ifdef CONFIG_DEBUG_ASSERTIONS_EXPRESSION
 #  define _ASSERT(f,file,line) __ASSERT__(f, file, line, #f)

--- a/include/assert.h
+++ b/include/assert.h
@@ -96,7 +96,7 @@
 #  define DEBUGVERIFY(f) _VERIFY(f, __DEBUG_ASSERT_FILE__, __DEBUG_ASSERT_LINE__)
 #else
 #  define DEBUGPANIC()
-#  define DEBUGASSERT(f) ((void)(1 || (f)))
+#  define DEBUGASSERT(f) ((void)(0))
 #  define DEBUGVERIFY(f) ((void)(f))
 #endif
 
@@ -106,7 +106,7 @@
  */
 
 #ifdef NDEBUG
-#  define assert(f) ((void)(1 || (f)))
+#  define assert(f) ((void)(0))
 #  define VERIFY(f) assert(f)
 #else
 #  define assert(f) _ASSERT(f, __ASSERT_FILE__, __ASSERT_LINE__)


### PR DESCRIPTION
## Summary
assert: change the do-while of assert to a conditional expression

According to the standard definition, assert should return a void expression
https://pubs.opengroup.org/onlinepubs/007904875/basedefs/assert.h.html

This patch involves two changes:

If you define the NDEBUG macro, assert does not use any parameters and directly returns a void expression.
assert should return a void expression and cannot use do-while statements.
If the following code , a compilation error will occur.

## Impact

## Testing
sim
